### PR TITLE
Update ProjectCard

### DIFF
--- a/src/components/general/ProjectCard.astro
+++ b/src/components/general/ProjectCard.astro
@@ -59,7 +59,9 @@ const { title, thumbnail, liveUrl, githubUrl } = projectDetail;
       )
     }
   </div>
-  <img
+  <a
+  href={liveUrl ? liveUrl : githubUrl}>
+    <img
     src={thumbnail}
     class="w-full h-auto scale-100 hover:scale-110 transition duration-[1.5s]"
     loading="lazy"
@@ -67,6 +69,7 @@ const { title, thumbnail, liveUrl, githubUrl } = projectDetail;
     height="100%"
     alt="featureImage"
   />
+  </a>
   <div
     class="absolute w-full bottom-0 left-0 backdrop-blur-md dark:text-white text-white bg-black/50 p-4 translate-y-[100%] group-hover:translate-y-0 transition duration-700"
   >

--- a/src/components/general/ProjectCard.astro
+++ b/src/components/general/ProjectCard.astro
@@ -60,7 +60,9 @@ const { title, thumbnail, liveUrl, githubUrl } = projectDetail;
     }
   </div>
   <a
-  href={liveUrl ? liveUrl : githubUrl}>
+  href={liveUrl ? liveUrl : githubUrl}
+  target="_blank"
+  >
     <img
     src={thumbnail}
     class="w-full h-auto scale-100 hover:scale-110 transition duration-[1.5s]"


### PR DESCRIPTION
To improve the user experience (UX), I added an <a> tag to the project image. The tag defaults to the live URL of the website. If a live URL does not exist, it replaces it with a GitHub URL instead. Finally, if neither a live URL nor GitHub is presented, it does not add a link. This change allows users to easily view a project without having to think much about where to go.