### PR TITLE
fix: featureProjects reduce logic

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,11 +7,12 @@ import Experience from "@components/home/Experience.astro";
 import ProjectsWrapper from "@components/general/ProjectsWrapper.astro";
 import MetaHead from "@components/general/MetaHead.astro";
 
-const featureProjects = info.projects.map((project, index) => {
-  if (project.isFeatured && index < 6) {
-    return project;
+const featureProjects = info.projects.reduce((accumulator, project) => {
+  if (accumulator.length < 6 && project.isFeatured) {
+    accumulator.push(project);
   }
-});
+  return accumulator;
+}, []);
 ---
 
 <!DOCTYPE html>


### PR DESCRIPTION
Fixes null-pointer exception. 
If you have 7+ featured projects, only the first 6 featured projects will be displayed. 