### PR TITLE
Fixing email address display bug

### DIFF
--- a/src/data/info.ts
+++ b/src/data/info.ts
@@ -81,7 +81,7 @@ export const info = {
     facebook: "https://www.facebook.com/profile.php?id=100022899849583",
     twitter: "https://twitter.com/Uzzii_21",
     github: "https://github.com/uzzii-21",
-    email: "uzairahmed@74372gmail.com",
+    email: "mailto:uzairahmed@74372gmail.com",
     linkedin: "https://www.linkedin.com/in/uzzii21/",
   },
 


### PR DESCRIPTION
Hi @uzzii-21,

I hope this message finds you well.

I'm sending you this pull request to review and merge the following changes to the [astro-portfolio repository](https://astro-portfolio-uzair.vercel.app/):

    Changed E-Mail text from `uzairahmed@74372gmail.com` to `mailto:uzairahmed@74372gmail.com`

I've made this change, because on your website, on your footer section, your e-mail address is being displayed like this: `https://astro-portfolio-uzair.vercel.app/uzairahmed@74372gmail.com`, instead of like this `mailto:uzairahmed@74372gmail.com`

This is my first time contributing, so I would really appreciate it, if you would take your time to review the code and if everything looks good, apply the changes I've made.

Wish you a great day!

Best Regards,
Jairo Morales